### PR TITLE
Use comma as a field separator

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -26,7 +26,7 @@ Only YAML files containing hashes and string values are supported (that includes
 ### As Ruby module
 
     require 'yaml2csv'
-    Yaml2csv::yaml2csv(string, :field_separator => ';')
+    Yaml2csv::yaml2csv(string, :field_separator => ',')
     Yaml2csv::csv2yaml(string)
 
 ### From command line
@@ -35,6 +35,6 @@ Convert file.yaml into CSV format:
 
     $ yaml2csv_conv file.yml
 
-Convert file.csv into YAML format (using ';' as field separator)
+Convert file.csv into YAML format (using ',' as field separator)
 
-    $ yaml2csv_conv -f";" -r file.csv
+    $ yaml2csv_conv -f"," -r file.csv


### PR DESCRIPTION
I think using a comma as a field separator is better as the example given in the README produces a CSV, which uses a comma as a field separator. Another option would be to change the example to use semicolons as a field separator.
